### PR TITLE
Add _replace endpoint to allow updating caches

### DIFF
--- a/handlers_test.go
+++ b/handlers_test.go
@@ -106,6 +106,7 @@ func TestPreseedHandler(t *testing.T) {
 	preseedHandler := PreseedHandler(
 		cache,
 		DefaultHasher{},
+		false,
 	)
 
 	// Seed /foobar
@@ -175,6 +176,7 @@ func TestPreseedHandlerWithRequestBody(t *testing.T) {
 	preseedHandler := PreseedHandler(
 		cache,
 		DefaultHasher{},
+		false,
 	)
 
 	// Seed /foobar
@@ -219,6 +221,7 @@ func TestPreseedHandlerBadJSON(t *testing.T) {
 	preseedHandler := PreseedHandler(
 		mockCacher{},
 		DefaultHasher{},
+		false,
 	)
 
 	req, _ := http.NewRequest("POST", "/_seed", strings.NewReader("BAD JSON"))
@@ -237,6 +240,7 @@ func TestPreseedHandlerCachesDuplicateRequest(t *testing.T) {
 	preseedHandler := PreseedHandler(
 		mockCacher{data: make(map[string]*CachedResponse)},
 		DefaultHasher{},
+		false,
 	)
 
 	payload := `{
@@ -278,6 +282,7 @@ func TestPreseedHandlerBadURL(t *testing.T) {
 	preseedHandler := PreseedHandler(
 		mockCacher{},
 		DefaultHasher{},
+		false,
 	)
 
 	payload := `{

--- a/main.go
+++ b/main.go
@@ -48,7 +48,8 @@ func main() {
 	cacher := NewDiskCacher(*dataDir)
 	cacher.SeedCache()
 	mux := http.NewServeMux()
-	mux.Handle("/_seed", PreseedHandler(cacher, hasher))
+	mux.Handle("/_seed", PreseedHandler(cacher, hasher, false))
+	mux.Handle("/_replace", PreseedHandler(cacher, hasher, true))
 	mux.Handle("/", CachedProxyHandler(serverURL, cacher, hasher))
 	log.Fatal(http.ListenAndServe(*host, mux))
 }


### PR DESCRIPTION
Added a new endpoint `/_replace` to allow updating previously cached or preseeded data. This allows simulating some real-life events during test runtime.

Also added a simple unit test for the new endpoint.